### PR TITLE
Coordinate array support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,19 +4,19 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="utm_zone", # Replace with your own username
-    version="1.0.1",
+    name="utm_zone",  # Replace with your own username
+    version="1.0.2",
     author="Per Liedman",
     author_email="per@liedman.net",
     description="Find the UTM zone for your GeoJSON",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/perliedman/py-utm-zone",
+    url="https://github.com/solvi-ab/py-utm-zone",
     packages=setuptools.find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: ISC License (ISCL)",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3',
+    python_requires=">=3",
 )

--- a/test/test_utm_zone.py
+++ b/test/test_utm_zone.py
@@ -1,0 +1,42 @@
+import utm_zone as UTM
+import unittest
+
+data = [
+    # Gothenburg, Sweden
+    ((11.974560, 57.708870), 32632),
+    # New York, USA
+    ((-74.00597, 40.71435), 32618),
+    # San Jose, Costa Rica
+    ((-84.087502, 9.934739), 32616),
+    # Capetown, South Africa (northen)
+    ((18.42406, -33.92487), 32734),
+    # Bali, Indonesia (northen)
+    ((115.188919, -8.409518), 32750),
+    # Edinburgh, Scotland
+    ((-3.200833, 55.948612), 32630),
+]
+
+
+class TestUtmZoneFromCoordinates(unittest.TestCase):
+    def test_to_epsg_from_latlon(self):
+        for latlon, expected_result in data:
+            result = UTM.epsg(latlon)
+            self.assertEqual(result, expected_result)
+
+
+class TestUtmZoneFromGeoJson(unittest.TestCase):
+    def to_geojson(self, pos):
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {"type": "Point", "coordinates": pos},
+                }
+            ],
+        }
+
+    def test_to_epsg_from_geojson(self):
+        for latlon, expected_result in data:
+            result = UTM.epsg(self.to_geojson(latlon))
+            self.assertEqual(result, expected_result)

--- a/utm_zone/__init__.py
+++ b/utm_zone/__init__.py
@@ -1,9 +1,11 @@
 from numbers import Number
 import math
+from collections.abc import Sequence
 
 def epsg(geojson):
   """
-  Provided a GeoJSON object, returns the EPSG code (integer) for the UTM zone best
+  Provided a GeoJSON object or a coordinate array [x, y],
+  returns the EPSG code (integer) for the UTM zone best
   matching the GeoJSON's geometry.
   """
   firstCoord = getFirstCoord(geojson)
@@ -12,7 +14,8 @@ def epsg(geojson):
 
 def proj(geojson):
   """
-  Provided a GeoJSON object, returns the Proj.4 definition for the UTM zone best
+  Provided a GeoJSON object or a coordinate array [x, y],
+  returns the Proj.4 definition for the UTM zone best
   matching the GeoJSON's geometry.
   """
   firstCoord = getFirstCoord(geojson)
@@ -28,7 +31,8 @@ def getFirstCoord(geojson):
       return coordinates
 
   firstCoord = \
-    recurse(geojson['coordinates']) if 'coordinates' in geojson \
+    geojson if isinstance(geojson, Sequence) and len(geojson) >= 2 \
+    else recurse(geojson['coordinates']) if 'coordinates' in geojson \
     else recurse(geojson['geometry']['coordinates']) if 'geometry' in geojson \
     else recurse(geojson['geometries'][0]['coordinates']) if 'geometries' in geojson \
     else recurse(geojson['features'][0]['geometry']['coordinates']) if 'features' in geojson \


### PR DESCRIPTION
Adds support for providing a single lng/lat coordinate, as an array, instead of only GeoJSON.

Basically same as #2 but without adding new functions. Uses tests from #2.